### PR TITLE
fix: fs client modtime not correct

### DIFF
--- a/pkg/fs/client/fs/file.go
+++ b/pkg/fs/client/fs/file.go
@@ -40,12 +40,13 @@ const (
 )
 
 type FileInfo struct {
-	path  string
-	size  int64
-	mtime uint64
-	isDir bool
-	mode  os.FileMode
-	sys   interface{}
+	path      string
+	size      int64
+	mtime     uint64
+	mtimensec uint64
+	isDir     bool
+	mode      os.FileMode
+	sys       interface{}
 }
 
 func NewFileInfo(attr *base.FileInfo) FileInfo {
@@ -84,7 +85,7 @@ func (i *FileInfo) Mode() os.FileMode {
 }
 
 func (i *FileInfo) ModTime() time.Time {
-	return time.Unix(int64(i.mtime), 0)
+	return time.Unix(0, int64(i.mtime)*1e9+int64(i.mtimensec))
 }
 
 func (i *FileInfo) Sys() interface{} {
@@ -262,11 +263,12 @@ func (f *File) ReadDir(n int) ([]os.DirEntry, error) {
 		}
 		path_ := f.fs.vfs.Meta.InoToPath(f.inode)
 		fileInfo := FileInfo{
-			path:  path_,
-			size:  int64(info.Attr.Size),
-			mtime: uint64(info.Attr.Mtimensec),
-			isDir: info.Attr.IsDir(),
-			mode:  utils.StatModeToFileMode(int(info.Attr.Mode)),
+			path:      path_,
+			size:      int64(info.Attr.Size),
+			mtime:     uint64(info.Attr.Mtime),
+			mtimensec: uint64(info.Attr.Mtimensec),
+			isDir:     info.Attr.IsDir(),
+			mode:      utils.StatModeToFileMode(int(info.Attr.Mode)),
 		}
 		dirEntry := NewDirEntry(entry, fileInfo)
 		osDirs[i] = &dirEntry
@@ -289,11 +291,12 @@ func (f *File) Readdir(n int) ([]os.FileInfo, error) {
 	for i, info := range entries {
 		path_ := f.fs.vfs.Meta.InoToPath(f.inode)
 		fileInfo := FileInfo{
-			path:  path_,
-			size:  int64(info.Attr.Size),
-			mtime: uint64(info.Attr.Mtimensec),
-			isDir: info.Attr.IsDir(),
-			mode:  utils.StatModeToFileMode(int(info.Attr.Mode)),
+			path:      path_,
+			size:      int64(info.Attr.Size),
+			mtime:     uint64(info.Attr.Mtime),
+			mtimensec: uint64(info.Attr.Mtimensec),
+			isDir:     info.Attr.IsDir(),
+			mode:      utils.StatModeToFileMode(int(info.Attr.Mode)),
 		}
 		dirInfos[i] = &fileInfo
 	}


### PR DESCRIPTION
<img width="1051" alt="image" src="https://user-images.githubusercontent.com/23272995/164193212-a39cbe0d-8a3f-4116-a14c-6b665753fd02.png">
for paddleflow fs client, if we use
`info, err := client.Stat(path)
info.ModTime()
`
ModTime is not correct, we need use time.Unix(0, int64(i.mtime)*1e9+int64(i.mtimensec)) get real time

![image](https://user-images.githubusercontent.com/23272995/164194171-8c3bec81-4309-41e2-b64b-dd7163d13d73.png)

![image](https://user-images.githubusercontent.com/23272995/164194208-fb3cd132-6706-4455-96ff-a576e925e0ad.png)

