### PR TITLE
cherry-pick from Fix: builtin single job cannot read job template (#667)

### DIFF
--- a/pkg/job/runtime/kubernetes/executor/singlejob.go
+++ b/pkg/job/runtime/kubernetes/executor/singlejob.go
@@ -96,12 +96,11 @@ func (sp *SingleJob) CreateJob() (string, error) {
 	log.Debugf("begin create job jobID:[%s]", jobID)
 
 	singlePod := &v1.Pod{}
-	if sp.YamlTemplateContent != nil && len(sp.YamlTemplateContent) != 0 {
-		if err := sp.createJobFromYaml(singlePod); err != nil {
-			log.Errorf("create job failed, err %v", err)
-			return "", err
-		}
+	if err := sp.createJobFromYaml(singlePod); err != nil {
+		log.Errorf("create job failed, err %v", err)
+		return "", err
 	}
+
 	if err := sp.validateJob(singlePod); err != nil {
 		log.Errorf("validate job failed, err: %v", err)
 		return "", err


### PR DESCRIPTION
cherry-pick from Fix: builtin single job cannot read job template (#667)