### PR TITLE
fix seize resource

### DIFF
--- a/pkg/common/k8s/status.go
+++ b/pkg/common/k8s/status.go
@@ -436,12 +436,11 @@ func getRayJobStatus(rayJobStatus *rayV1alpha1.RayJobStatus) (schema.JobStatus, 
 	msg := ""
 	jobStatus := rayJobStatus.JobStatus
 	switch jobStatus {
-	case rayV1alpha1.JobStatusPending:
+	// TODO JobStatusStopped should be processed in another way when the feature "unused status Stopped" is fixed by ray-operator
+	case rayV1alpha1.JobStatusPending, rayV1alpha1.JobStatusStopped:
 		status, msg = schema.StatusJobPending, "job is pending"
 	case rayV1alpha1.JobStatusRunning:
 		status, msg = schema.StatusJobRunning, "job is running"
-	case rayV1alpha1.JobStatusStopped:
-		status, msg = schema.StatusJobTerminated, "job is terminated"
 	case rayV1alpha1.JobStatusSucceeded:
 		status, msg = schema.StatusJobSucceeded, "job is succeeded"
 	case rayV1alpha1.JobStatusFailed:


### PR DESCRIPTION
 Fix preemption job recovery issue
1. Add a `curl stop` to the prestop of each worker, forcing it to `STOP` the rayjob before it hangs
2. Next, add a livenessProbe to the header
3. Keep checking the status of this rayjob, if it is `STOP`, crash itself
4. Last, the header is restarted, so that a brand new rayjob is resubmitted