### PR TITLE
fix: Concurrent read cache may be read delete file

### DIFF
--- a/pkg/fs/client/cache/cache.go
+++ b/pkg/fs/client/cache/cache.go
@@ -169,7 +169,7 @@ func (r *rCache) ReadAt(buf []byte, off int64) (n int, err error) {
 	blockOff := r.off(int(off))
 	start := time.Now()
 	nReadFromCache, hitCache := r.readCache(buf, key, blockOff)
-	if hitCache {
+	if hitCache && nReadFromCache != 0 {
 		// metrics
 		cacheHits.Inc()
 		cacheHitBytes.Add(float64(nReadFromCache))

--- a/pkg/fs/client/fs/pfs_client_test.go
+++ b/pkg/fs/client/fs/pfs_client_test.go
@@ -824,7 +824,7 @@ func TestFSClient_Concurrent_Read(t *testing.T) {
 	assert.Equal(t, nil, err)
 	writer.Close()
 	var wg sync.WaitGroup
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 500; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/pkg/fs/client/fs/pfs_client_test.go
+++ b/pkg/fs/client/fs/pfs_client_test.go
@@ -824,7 +824,7 @@ func TestFSClient_Concurrent_Read(t *testing.T) {
 	assert.Equal(t, nil, err)
 	writer.Close()
 	var wg sync.WaitGroup
-	for i := 0; i < 500; i++ {
+	for i := 0; i < 5; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/pkg/fs/client/vfs/reader.go
+++ b/pkg/fs/client/vfs/reader.go
@@ -116,9 +116,6 @@ func (fh *fileReader) Read(buf []byte, off uint64) (int, syscall.Errno) {
 				break
 			}
 			off += uint64(nread)
-			if nread == 0 {
-				break
-			}
 		}
 	} else {
 		if fh.fd == nil {


### PR DESCRIPTION
### PR types
Bug fixes
### PR changes
OPs
### Describe
Concurrent read data cache may be read delete file, nread may be equal zero