### PR TITLE
Fix bug that get empty namespace when sync volcano queue

### DIFF
--- a/pkg/job/runtime_v2/queue/vcqueue/kube_vc_queue.go
+++ b/pkg/job/runtime_v2/queue/vcqueue/kube_vc_queue.go
@@ -152,7 +152,7 @@ func (vcq *KubeVCQueue) AddEventListener(ctx context.Context, listenerType strin
 func (vcq *KubeVCQueue) add(obj interface{}) {
 	newObj := obj.(*unstructured.Unstructured)
 	name := newObj.GetName()
-	// convert to ElasticResourceQuota struct
+	// convert to vc queue struct
 	vcQueue := &v1beta1.Queue{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(newObj.Object, vcQueue); err != nil {
 		log.Errorf("convert unstructured object [%+v] to %s failed. err: %s", obj, vcq.String(name), err)
@@ -166,7 +166,7 @@ func (vcq *KubeVCQueue) add(obj interface{}) {
 		// set vc queue status
 		Status:    getVCQueueStatus(vcQueue.Status.State),
 		QuotaType: pfschema.TypeVolcanoCapabilityQuota,
-		Namespace: newObj.GetNamespace(),
+		Namespace: "default",
 	}
 	vcq.workQueue.Add(qSyncInfo)
 	log.Infof("watch %s is added", vcq.String(name))


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs: fix bug that get empty namespace when sync volcano queue

### Describe
<!-- Describe what this PR does -->
Bug fixes
