### PR TITLE
[pipeline] update createPipeline and UpdatePipeline API: add YamlRaw …

### DIFF
--- a/client/paddleflow/client.py
+++ b/client/paddleflow/client.py
@@ -535,15 +535,13 @@ class Client(object):
         self.pre_check()
         return ClusterServiceApi.list_cluster_resource(self.paddleflow_server, clustername, self.header)
 
-    def create_pipeline(self, fs_name, yaml_path=None, desc=None, username=None):
+    def create_pipeline(self, fs_name=None, yaml_path=None, desc=None, username=None, yaml_raw=None):
         """
         create pipeline
         """
         self.pre_check()
-        if fs_name is None or fs_name.strip() == "":
-            raise PaddleFlowSDKException("InvalidFsName", "fsname should not be none or empty")
         return PipelineServiceApi.create_pipeline(self.paddleflow_server, fs_name, yaml_path, desc,
-                                                  username, self.header)
+                                                  username, self.header, yaml_raw)
 
     def list_pipeline(self, user_filter=None, name_filter=None, max_keys=None, marker=None):
         """
@@ -571,19 +569,15 @@ class Client(object):
             raise PaddleFlowSDKException("InvalidPipelineID", "pipelineid should not be none or empty")
         return PipelineServiceApi.delete_pipeline(self.paddleflow_server, pipeline_id, self.header)
 
-    def update_pipeline(self, pipeline_id, fs_name, yaml_path, username=None, desc=None):
+    def update_pipeline(self, pipeline_id, fs_name=None, yaml_path=None, username=None, desc=None, yaml_raw=None):
         """
             update pipeline
         """
         self.pre_check()
         if pipeline_id is None or pipeline_id == "":
             raise PaddleFlowSDKException("InvalidPipelineID", "pipeline_id should not be none or empty")
-        if fs_name is None or fs_name == "":
-            raise PaddleFlowSDKException("InvalidFSName", "fs_name should not be none or empty")
-        if yaml_path is None or yaml_path == "":
-            raise PaddleFlowSDKException("InvalidYamlPath", "yaml_path should not be none or empty")
         return PipelineServiceApi.update_pipeline(self.paddleflow_server, self.header, pipeline_id, fs_name, yaml_path,
-                                                  username, desc)
+                                                  username, desc, yaml_raw)
 
     def show_pipeline_version(self, pipeline_id, pipeline_version_id):
         """

--- a/client/paddleflow/pipeline/pipeline_api.py
+++ b/client/paddleflow/pipeline/pipeline_api.py
@@ -15,7 +15,7 @@ limitations under the License.
 
 #!/usr/bin/env python3
 # -*- coding:utf8 -*-
-
+import base64
 import json
 from urllib import parse
 from paddleflow.common.exception.paddleflow_sdk_exception import PaddleFlowSDKException
@@ -32,7 +32,7 @@ class PipelineServiceApi(object):
         """
 
     @classmethod
-    def create_pipeline(self, host, fs_name, yaml_path=None, desc=None, username=None, header=None):
+    def create_pipeline(self, host, fs_name=None, yaml_path=None, desc=None, username=None, header=None, yaml_raw=None):
         """
             create pipeline
             this method returns a pipeline brief info and a pipeline version brief list info
@@ -40,13 +40,20 @@ class PipelineServiceApi(object):
         if not header:
             raise PaddleFlowSDKException("InvalidRequest",
                                          "paddleflow should login first")
-        body = {"fsname": fs_name}
+        body = {}
+        if fs_name:
+            body["fsname"] = fs_name
         if yaml_path:
             body['yamlPath'] = yaml_path
         if desc:
             body['desc'] = desc
         if username:
             body['username'] = username
+        if yaml_raw:
+            if isinstance(yaml_raw, bytes):
+                body['yamlRaw'] = base64.b64encode(yaml_raw).decode()
+            else:
+                raise PaddleFlowSDKException("InvalidRequest", "yaml_raw must be bytes type")
 
         response = api_client.call_api(method="POST",
                                        url=parse.urljoin(
@@ -162,20 +169,26 @@ class PipelineServiceApi(object):
             return True, None
 
     @classmethod
-    def update_pipeline(self, host, header, pipeline_id, fs_name, yaml_path, username=None, desc=None):
+    def update_pipeline(self, host, header, pipeline_id, fs_name=None, yaml_path=None, username=None, desc=None, yaml_raw=None):
         """update pipeline (create pipeline version)
         """
         if not header:
             raise PaddleFlowSDKException("InvalidRequest",
                                          "paddleflow should login first")
-        body = {
-            'fsName': fs_name,
-            'yamlPath': yaml_path,
-        }
+        body = {}
+        if fs_name is not None:
+            body['fsName'] = fs_name
+        if yaml_path is not None:
+            body['yamlPath'] = yaml_path
         if username:
             body['username'] = username
         if desc:
             body['desc'] = desc
+        if yaml_raw:
+            if isinstance(yaml_raw, bytes):
+                body['yamlRaw'] = base64.b64encode(yaml_raw).decode()
+            else:
+                raise PaddleFlowSDKException("InvalidRequest", "yaml_raw must be bytes type")
 
         response = api_client.call_api(
             method="POST",

--- a/client/test/test_pipeline/test_dsl/test_pipeline.py
+++ b/client/test/test_pipeline/test_dsl/test_pipeline.py
@@ -130,6 +130,38 @@ class TestPipeline(object):
         with pytest.raises(PaddleFlowSDKException):
             pipeline.run(pf_config, "xiaodu")
 
+    @pytest.mark.run
+    def test_create(self, mocker):
+        """ test run 
+        """
+        pf_config = str(Path(__file__).parent / "pf.config")
+        pipeline = Pipeline(name="hello", docker_env="python:3.9")(hello_with_io)(name="pipeline", age=17)
+
+        mocker.patch("paddleflow.Client.login", return_value=(True, ""))
+        mocker.patch("paddleflow.Client.create_pipeline", return_value=None)
+        mocker.patch("paddleflow.Client.pre_check", return_value=None)
+        
+        pipeline.create(pf_config, "xiaodu", "just for test")
+        pipeline._client = None
+        mocker.patch("paddleflow.Client.login", return_value=(False, ""))
+        with pytest.raises(PaddleFlowSDKException):
+            pipeline.run(pf_config, "xiaodu", "just for test")
+
+        with pytest.raises(PaddleFlowSDKException):
+            pipeline.run(pf_config, "xiaodu", "just for test")
+          
+    @pytest.mark.update
+    def test_update(self, mocker):
+        """ test run 
+        """
+        pf_config = str(Path(__file__).parent / "pf.config")
+        pipeline = Pipeline(name="hello", docker_env="python:3.9")(hello_with_io)(name="pipeline", age=17)
+
+        mocker.patch("paddleflow.Client.login", return_value=(True, ""))
+        mocker.patch("paddleflow.Client.update_pipeline", return_value=None)
+        mocker.patch("paddleflow.Client.pre_check", return_value=None)
+        pipeline.update("0123", pf_config, "xiaodu", "just for test")
+
     @pytest.mark.post
     def test_post_process(self):
         """ test set_post_process and get_post_process

--- a/docs/zh_cn/reference/sdk_reference/pipeline_dsl_reference.md
+++ b/docs/zh_cn/reference/sdk_reference/pipeline_dsl_reference.md
@@ -114,7 +114,6 @@ ppl.entry_points
 #### 返回值说明
 一个Dict，其key为节点的名字，value为节点实例
 
-
 ### 1.7、获取pipeline名字
 ```python3
 ppl.name
@@ -163,6 +162,43 @@ ppl.add_env({"env1": "env1"})
 
 #### 返回值说明
 无返回值
+
+### 1.11 创建工作流模板
+```python3
+ppl.create()
+```
+
+#### 接口入参说明
+字段名称 | 字段类型 | 字段含义 | 是否必须 | 备注 |
+|:---:|:---:|:---:|:---:|:---:|
+|config | string|配置文件路径| 否 | 配置文件的内容请参考[这里][config_content] |
+|desc| string | 工作流模板的描述 | 否 | | 
+|username| string| 模板所属用户名称 | 否 | | 
+
+#### 接口返回说明
+|字段名称 | 字段类型 | 字段含义
+|:---:|:---:|:---:|
+|ret| bool| 操作成功返回True，失败返回False
+|response| -| 失败返回失败message，成功返回dict：{'name': 名称, 'pplID': 工作流模板id, 'pplVerID': 工作流模板版本id}
+
+### 1.12 工作流模板更新（版本创建）
+```python3
+ppl.update("123")
+```
+
+#### 接口入参说明
+字段名称 | 字段类型 | 字段含义 | 是否必须 | 备注 |
+|:---:|:---:|:---:|:---:|:---:|
+|pipeline_id| string |工作流模板id | 是 | | 
+|config | string|配置文件路径| 否 | 配置文件的内容请参考[这里][config_content] |
+|desc| string | 工作流模板的描述 | 否 | | 
+|username| string| 模板所属用户名称 | 否 | | 
+
+#### 接口返回说明
+|字段名称 | 字段类型 | 字段含义
+|:---:|:---:|:---:|
+|ret| bool| 操作成功返回True，失败返回False
+|response| -| 失败返回失败message，成功返回dict: {'pipelineID': pplID, 'pipelineVersionID': pplVerID}
 
 ## 2、ContainerStep
 ### 2.1 初始化

--- a/docs/zh_cn/reference/sdk_reference/sdk_reference.md
+++ b/docs/zh_cn/reference/sdk_reference/sdk_reference.md
@@ -495,7 +495,7 @@ ret, response = client.create_run(fsname="fsname", runyamlpath="./run.yaml")
 |run_name| string (optional)|工作流名称
 |desc| string (optional)|工作流描述
 |run_yaml_path| string (optional)|指定的yaml 文件路径，发起任务方式之一
-|run_yaml_raw| string (optional)|本地yaml 文件路径，发起任务方式之一
+|run_yaml_raw| string (optional)|yaml文件内容的bytes形式，发起任务方式之一
 |pipeline_id| string (optional)|pipeline模板的ID，发起任务方式之一
 |pipeline_version_id| string(optional)|pipeline模板的版本ID，如设置了pipeline_id，则必须同时设置该参数
 |param| dict (optional)|工作流运行参数 如{"epoch":100}
@@ -778,8 +778,9 @@ ret, response = client.create_pipeline()
 #### 接口入参说明
 |字段名称 | 字段类型 | 字段含义
 |:---:|:---:|:---:|
-|fs_name| string (required)|共享存储名称
-|yaml_path| string (optional)|yaml 文件所在路径
+|fs_name| string (optional)|共享存储名称
+|yaml_path| string (optional)|yaml 文件所在路径, 与yaml_raw二选一
+|yaml_raw| bytes (optional) | yaml文件内容的bytes形式, 与yaml_path二选一
 |desc| string (optional)|工作流模板的描述
 |username| string (optional)|模板所属用户名称
 
@@ -880,8 +881,9 @@ ret, response, ppl_ver_id = client.update_pipeline("pipeline_id", "fs_name", "ya
 |字段名称 | 字段类型 | 字段含义
 |:---:|:---:|:---:|
 |pipeline_id| string (required) |工作流模板id
-|fs_name| string (required) |共享存储名称
-|yaml_path| string (required) |yaml 文件所在路径
+|fs_name| string (optional) |共享存储名称
+|yaml_path| string (optional) |yaml 文件所在路径, 与yaml_raw二选一
+|yaml_raw| bytes (optional) | yaml文件内容的bytes形式, 与yaml_path二选一
 |desc| string (optional)| 工作流模板的描述
 |username| string (optional) | 模板所属用户名称
 


### PR DESCRIPTION
…parameter (#900)

### PR types
 Function optimization

### PR changes
 APIs

### Describe
现在 CreatePipeline（UpdatePipeline） 接口只支持 yamlPath 这一个参数（之前未对齐），但是PDC这边不计划使用共享存储，所以如果要创建 pipeline 的话呢，就需要CreatePipeline（UpdatePipeline）接口支持 yamlRaw 参数（DSL的同步增加Create 和Update）.