### PR TITLE
[pipeline] fix bug: there is no endTime where job is terminated (#966)

### DIFF
--- a/pkg/apiserver/models/run_job.go
+++ b/pkg/apiserver/models/run_job.go
@@ -219,6 +219,16 @@ func (rj *RunJob) decode() error {
 	return nil
 }
 
+func (rj *RunJob) Finished() bool {
+	if rj.Status == schema.StatusJobCancelled || rj.Status == schema.StatusJobFailed ||
+		rj.Status == schema.StatusJobSucceeded || rj.Status == schema.StatusJobSkipped ||
+		rj.Status == schema.StatusJobTerminated {
+		return true
+	}
+
+	return false
+}
+
 func (rj *RunJob) Trans2JobView() schema.JobView {
 	// 该函数通过数据库中run_job记录的信息，生成JobView，该JobView的信息是不全的：少了deps
 	// 差别可参考ParseJobView函数
@@ -232,7 +242,8 @@ func (rj *RunJob) Trans2JobView() schema.JobView {
 		newEnv[k] = v
 	}
 	newEndTime := ""
-	if rj.Status == schema.StatusJobCancelled || rj.Status == schema.StatusJobFailed || rj.Status == schema.StatusJobSucceeded || rj.Status == schema.StatusJobSkipped {
+	if rj.Status == schema.StatusJobFailed || rj.Status == schema.StatusJobSucceeded ||
+		rj.Status == schema.StatusJobTerminated {
 		newEndTime = rj.UpdateTime
 	}
 	newFsMount := append(rj.ExtraFS, []schema.FsMount{}...)

--- a/pkg/apiserver/models/run_job_test.go
+++ b/pkg/apiserver/models/run_job_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserve.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/PaddlePaddle/PaddleFlow/pkg/common/schema"
+)
+
+func TestFinished(t *testing.T) {
+	rj := RunJob{
+		Status: schema.StatusJobCancelled,
+	}
+
+	assert.True(t, rj.Finished())
+
+	rj.Status = ScheduleStatusRunning
+	assert.False(t, rj.Finished())
+}
+
+func TestTransJob(t *testing.T) {
+	rj := RunJob{
+		Status: schema.StatusJobCancelled,
+	}
+
+	jobView := rj.Trans2JobView()
+	assert.Equal(t, jobView.EndTime, "")
+
+	rj = RunJob{
+		Status:     schema.StatusJobTerminated,
+		UpdateTime: "2022-01-01 00:01:11",
+	}
+
+	jobView = rj.Trans2JobView()
+	assert.Equal(t, jobView.EndTime, "2022-01-01 00:01:11")
+
+	rj = RunJob{
+		Status:     schema.StatusJobCancelled,
+		UpdateTime: "2022-01-01 00:01:11",
+	}
+
+	jobView = rj.Trans2JobView()
+	assert.Equal(t, jobView.EndTime, "")
+
+	rj = RunJob{
+		Status:     schema.StatusJobRunning,
+		UpdateTime: "2022-01-01 00:01:11",
+	}
+
+	jobView = rj.Trans2JobView()
+	assert.Equal(t, jobView.EndTime, "")
+}


### PR DESCRIPTION
### PR types
 Bug fixes 

### PR changes
APIs

### Describe
修复job处于 teminated 状态时，getRun返回值值没有 endtime 的bug 
