### PR TITLE
security fix, fix python cli pyyaml from 5.3 to 5.4

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -2,4 +2,4 @@ requests
 click==7.1.2
 tabulate==0.8.9
 setuptools >= 21.0.0
-pyyaml==5.3.1
+pyyaml==5.4


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
security fix, fix python cli pyyaml from 5.3 to 5.4