### PR TITLE
fs client remove all have not check if a entry is dir

### DIFF
--- a/pkg/fs/client/fs/hdfs_test.go
+++ b/pkg/fs/client/fs/hdfs_test.go
@@ -39,19 +39,19 @@ func TestHDFS(t *testing.T) {
 	SetDataCache(d)
 	client := getHDFSClient(t)
 	defer func() {
-		// err := client.Remove(testBigFileName)
-		// assert.Equal(t, nil, err)
-		// err = client.Remove(testSmallFileName)
-		// assert.Equal(t, nil, err)
-		// os.Remove(testBigFileName)
+		err := client.Remove(testBigFileName)
+		assert.Equal(t, nil, err)
+		err = client.Remove(testSmallFileName)
+		assert.Equal(t, nil, err)
+		os.Remove(testBigFileName)
 		os.RemoveAll("./tmp")
 		os.RemoveAll("./mock-cache")
 	}()
 
 	chown(t, client)
-	//testBigFile(t, client)
-	// testSmallFile(t, client)
-	// testMkdirAndList(t, client)
+	testBigFile(t, client)
+	testSmallFile(t, client)
+	testMkdirAndList(t, client)
 }
 
 func chown(t *testing.T, client FSClient) {

--- a/pkg/fs/client/fs/pfs_client.go
+++ b/pkg/fs/client/fs/pfs_client.go
@@ -226,7 +226,6 @@ func (c *PFSClient) removeAll(path string) error {
 	if utils.EndsWithDot(path) {
 		return &os.PathError{Op: "RemoveAll", Path: path, Err: syscall.EINVAL}
 	}
-
 	parent, err := c.pfs.Open(path)
 	if os.IsNotExist(err) {
 		// If parent does not exist, base cannot exist. Fail silently
@@ -236,8 +235,10 @@ func (c *PFSClient) removeAll(path string) error {
 		log.Errorf("Open[%s] failed: %v", path, err)
 		return err
 	}
+	if !parent.attr.isDir {
+		return c.Remove(path)
+	}
 	defer parent.Close()
-
 	dirs, err := parent.Readdirnames(-1)
 	if err != nil {
 		log.Errorf("Readdirnames failed: %v", err)


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs 

### Describe
fs client remove all have not check if a entry is dir
