### PR TITLE
s3 api not allow to delete over 1k obj at once, rename op may trigger…

### DIFF
--- a/pkg/fs/client/ufs/object/bos_test.go
+++ b/pkg/fs/client/ufs/object/bos_test.go
@@ -102,18 +102,34 @@ func TestBos_Deletes(t *testing.T) {
 			fields:  fields{},
 			wantErr: true,
 		},
+		{
+			name: "sts true",
+			args: args{
+				keys: []string{"aa", "bb"},
+			},
+			fields: fields{
+				bosClient: &bos.Client{},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			storage := Bos{
-				bucket:    tt.fields.bucket,
-				bosClient: tt.fields.bosClient,
+				bucket:     tt.fields.bucket,
+				bosClient:  tt.fields.bosClient,
+				startBySts: true,
 			}
+			p1 := gomonkey.ApplyMethod(reflect.TypeOf(&bos.Client{}), "DeleteObject", func(_ *bos.Client, bucket, object string) error {
+				return nil
+			})
+			defer p1.Reset()
 			if err := storage.Deletes(tt.args.keys); (err != nil) != tt.wantErr {
 				t.Errorf("Deletes() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
+
 }
 
 func TestBos_AbortUpload(t *testing.T) {


### PR DESCRIPTION
… this restriction

### PR types
 Bug fixes

### PR changes
APIs
### Describe
修复以下几个bug:
1.  s3存储deletes函数不允许一次删除超过1k个object 而rename操作可能会触发这个限制 导致报错
2. s3存储的rename操作，对每个object，会开启一个携程去执行copy函数，可能会引发携程溢出，导致panic
3.  以sts启动的bos-client 不允许一次性delete多个object。 进而造成性能损耗，因此对以sts启动和和非sts启动的bos-client的rename操作做了区分
