### PR TITLE
feat(queue): get the namespace of queue from annotations when sync volcano queue

### DIFF
--- a/pkg/common/schema/job.go
+++ b/pkg/common/schema/job.go
@@ -157,6 +157,8 @@ const (
 	QueueLabelKey        = "volcano.sh/queue-name"
 	SparkAPPJobNameLabel = "sparkoperator.k8s.io/app-name"
 
+	QueueNamespaceAnnotation = "paddleflow/queue-namespace"
+
 	JobPrefix            = "job"
 	DefaultSchedulerName = "volcano"
 	DefaultFSMountPath   = "/home/paddleflow/storage/mnt"

--- a/pkg/job/runtime_v2/queue/vcqueue/kube_vc_queue.go
+++ b/pkg/job/runtime_v2/queue/vcqueue/kube_vc_queue.go
@@ -153,6 +153,10 @@ func (vcq *KubeVCQueue) AddEventListener(ctx context.Context, listenerType strin
 func (vcq *KubeVCQueue) add(obj interface{}) {
 	newObj := obj.(*unstructured.Unstructured)
 	name := newObj.GetName()
+	namespace := newObj.GetAnnotations()[pfschema.QueueNamespaceAnnotation]
+	if namespace == "" {
+		namespace = "default"
+	}
 	// convert to vc queue struct
 	vcQueue := &v1beta1.Queue{}
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(newObj.Object, vcQueue); err != nil {
@@ -167,7 +171,7 @@ func (vcq *KubeVCQueue) add(obj interface{}) {
 		// set vc queue status
 		Status:    getVCQueueStatus(vcQueue.Status.State),
 		QuotaType: pfschema.TypeVolcanoCapabilityQuota,
-		Namespace: "default",
+		Namespace: namespace,
 	}
 	vcq.workQueue.Add(qSyncInfo)
 	log.Infof("watch %s is added", vcq.String(name))


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Get the namespace of queue from annotations when sync volcano queue.
