### PR TITLE
支持hdfs配置UseDatanodeHostname

### DIFF
--- a/pkg/fs/client/ufs/hdfs.go
+++ b/pkg/fs/client/ufs/hdfs.go
@@ -636,6 +636,10 @@ func NewHdfsFileSystem(properties map[string]interface{}) (UnderFileStorage, err
 	options := hdfs.ClientOptions{
 		Addresses: strings.Split(nameNodeAddress, ","),
 	}
+	useDatanodeHostname, ok := properties[common.UseDatanodeHostname].(bool)
+	if ok && useDatanodeHostname {
+		options.UseDatanodeHostname = true
+	}
 	options.User = properties[common.UserKey].(string)
 	cli, err := hdfs.NewClient(options)
 	if err != nil {

--- a/pkg/fs/client/ufs/hdfs_kerberos.go
+++ b/pkg/fs/client/ufs/hdfs_kerberos.go
@@ -123,6 +123,10 @@ func NewHdfsWithKerberosFileSystem(properties map[string]interface{}) (UnderFile
 	options := hdfs.ClientOptions{
 		Addresses: strings.Split(nameNodeAddress, ","),
 	}
+	useDatanodeHostname, ok := properties[common.UseDatanodeHostname].(bool)
+	if ok && useDatanodeHostname {
+		options.UseDatanodeHostname = true
+	}
 	krbConfig, _ := buildKerberosConf(properties)
 	if krbClient, err := NewKerberosClientWithKeyTab(krbConfig); err == nil {
 		options.KerberosClient = krbClient

--- a/pkg/fs/common/common.go
+++ b/pkg/fs/common/common.go
@@ -38,10 +38,11 @@ const (
 	Type    = "type"
 
 	// HDFS properties
-	NameNodeAddress = "dfs.namenode.address"
-	UserKey         = "user"
-	BlockSizeKey    = "blockSize"
-	ReplicationKey  = "replication"
+	NameNodeAddress     = "dfs.namenode.address"
+	UseDatanodeHostname = "dfs.client.use.datanode.hostname"
+	UserKey             = "user"
+	BlockSizeKey        = "blockSize"
+	ReplicationKey      = "replication"
 
 	Sts             = "sts"
 	Token           = "token"


### PR DESCRIPTION
### PR types
Function optimization

### PR changes
OPs

### Describe
如果hdfs使用了双网卡，比如内部通信用万兆网卡，外部通信用千兆网卡，client端就需要通过配置UseDatanodeHostname来访问hdfs
